### PR TITLE
Add Argo CD demo pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,43 @@
+name: CI/CD
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/pipeline_blog:latest
+
+      - name: Deploy via ArgoCD
+        uses: argoproj-labs/argocd-action@v2
+        with:
+          version: v2.7.7
+          command: app
+          args: sync blog --prune --self-heal
+          server: ${{ secrets.ARGOCD_SERVER }}
+          username: ${{ secrets.ARGOCD_USERNAME }}
+          password: ${{ secrets.ARGOCD_PASSWORD }}
+          insecure: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY blog /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # pipeline_with_argocd
-Pipeline with Argo CD
+
+Ce dépôt fournit un exemple minimal de pipeline CI/CD utilisant **Argo CD** pour déployer un simple blog statique.
+
+## Structure du projet
+
+- `blog/` : contient la page HTML du blog.
+- `Dockerfile` : image basée sur Nginx servant les fichiers statiques.
+- `k8s/` : manifests Kubernetes (Deployment et Service).
+- `argocd/application.yaml` : définition de l'application Argo CD.
+- `.github/workflows/ci-cd.yml` : pipeline GitHub Actions de build et de déploiement.
+
+## Utilisation
+
+1. Poussez ce dépôt sur GitHub.
+2. Configurez les secrets `ARGOCD_SERVER`, `ARGOCD_USERNAME` et `ARGOCD_PASSWORD` dans votre repository GitHub pour permettre à la pipeline de déclencher Argo CD.
+3. Adaptez dans `k8s/deployment.yaml` l'image container `ghcr.io/USERNAME/pipeline_blog:latest` avec votre nom d'utilisateur.
+4. Installez Argo CD sur votre cluster Kubernetes puis appliquez `argocd/application.yaml`.
+5. À chaque `git push` sur la branche `main`, le workflow construit l'image, la pousse sur GHCR puis synchronise l'application via Argo CD.

--- a/argocd/application.yaml
+++ b/argocd/application.yaml
@@ -1,0 +1,17 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: blog
+spec:
+  destination:
+    namespace: default
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    repoURL: https://github.com/USERNAME/pipeline_with_argocd.git
+    targetRevision: HEAD
+    path: k8s
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Blog DevOps</title>
+</head>
+<body>
+  <h1>Bienvenue sur le blog DevOps</h1>
+  <p>Ce site est déployé via Argo CD.</p>
+</body>
+</html>

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: blog
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: blog
+  template:
+    metadata:
+      labels:
+        app: blog
+    spec:
+      containers:
+        - name: blog
+          image: ghcr.io/USERNAME/pipeline_blog:latest
+          ports:
+            - containerPort: 80

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: blog
+spec:
+  type: ClusterIP
+  selector:
+    app: blog
+  ports:
+    - port: 80
+      targetPort: 80


### PR DESCRIPTION
## Summary
- add an example blog in `blog/`
- create a Dockerfile
- define k8s manifests and Argo CD application
- add GitHub Actions workflow
- document how to use the pipeline

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685825770fe483289aa418eafc641641