### PR TITLE
Add simple DevOps blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # pipeline_with_argocd
 
-Ce dépôt fournit un exemple minimal de pipeline CI/CD utilisant **Argo CD** pour déployer un simple blog statique.
+Ce dépôt fournit un exemple minimal de pipeline CI/CD utilisant **Argo CD** pour déployer un simple blog statique sur le thème DevOps.
 
 ## Structure du projet
 
-- `blog/` : contient la page HTML du blog.
+- `blog/` : contient les pages HTML du blog DevOps.
 - `Dockerfile` : image basée sur Nginx servant les fichiers statiques.
 - `k8s/` : manifests Kubernetes (Deployment et Service).
 - `argocd/application.yaml` : définition de l'application Argo CD.

--- a/blog/about.html
+++ b/blog/about.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>About - DevOps Blog</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    header { text-align: center; }
+    nav a { margin-right: 1rem; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>About This Blog</h1>
+    <nav>
+      <a href="index.html">Home</a>
+    </nav>
+  </header>
+  <p>This simple static blog demonstrates a CI/CD pipeline with Argo CD.</p>
+</body>
+</html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,11 +1,32 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Blog DevOps</title>
+  <title>DevOps Blog</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    header { text-align: center; }
+    nav a { margin-right: 1rem; }
+    article { margin-bottom: 2rem; }
+  </style>
 </head>
 <body>
-  <h1>Bienvenue sur le blog DevOps</h1>
-  <p>Ce site est déployé via Argo CD.</p>
+  <header>
+    <h1>DevOps Blog</h1>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+    </nav>
+  </header>
+  <section>
+    <article>
+      <h2><a href="posts/getting-started-with-ci.html">Getting Started with CI</a></h2>
+      <p>Learn how to automate your builds with a simple CI pipeline.</p>
+    </article>
+    <article>
+      <h2><a href="posts/argo-cd-basic-setup.html">Argo CD Basic Setup</a></h2>
+      <p>An introduction to deploying with Argo CD.</p>
+    </article>
+  </section>
 </body>
 </html>

--- a/blog/posts/argo-cd-basic-setup.html
+++ b/blog/posts/argo-cd-basic-setup.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Argo CD Basic Setup</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    nav a { margin-right: 1rem; }
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="../index.html">Home</a>
+  </nav>
+  <h1>Argo CD Basic Setup</h1>
+  <p>Argo CD automates the deployment of applications to Kubernetes using Git as the source of truth. Install it on your cluster and create an Application to start syncing.</p>
+</body>
+</html>

--- a/blog/posts/getting-started-with-ci.html
+++ b/blog/posts/getting-started-with-ci.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Getting Started with CI</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    nav a { margin-right: 1rem; }
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="../index.html">Home</a>
+  </nav>
+  <h1>Getting Started with Continuous Integration</h1>
+  <p>Continuous Integration (CI) automatically builds and tests your code each time you push changes. It helps detect issues early and keeps your project healthy.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- overhaul the static blog
- add About page
- add Getting Started and Argo CD posts
- update README to mention DevOps theme

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859a1bfff4c8328852cd7c65bdc3aab